### PR TITLE
Free resources on Close

### DIFF
--- a/compression_zstd.go
+++ b/compression_zstd.go
@@ -85,6 +85,7 @@ func (src *zstdReadCloser) Read(buf []byte) (int, error) {
 }
 
 func (src *zstdReadCloser) Close() error {
+	src.sr.Close()
 	return src.inner.Close()
 }
 


### PR DESCRIPTION
We also need to Close the zstd reader, not just the underlying
ReadCloser.